### PR TITLE
close JSDoc Automation

### DIFF
--- a/.github/workflows/jsdoc.yml
+++ b/.github/workflows/jsdoc.yml
@@ -1,8 +1,8 @@
 name: jsdoc
 on:
   push:
-    # branches:
-      # - main 
+    branches:
+      - main 
   pull_request:
 
 jobs:


### PR DESCRIPTION
The jsdoc.yml file should be able to generate a website of documentation successfully when it's in the main branch.
But for the first time that it's activated, it will fail and ask for approval for the public key. This is when someone who has access to settings should go to "Settings-Security-Deploy keys" and click "approve" on the public key. After this operation, the action should be working as expected